### PR TITLE
Event branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,25 +106,13 @@ Default shortcut: Ctrl + Alt + D
       cursor leaves this area for the first time (after that the area
       is disabled and the rotation is allowed everywhere)
   5.  Increase/decrease (can't be negative!) TIMER_INTERVAL (milliseconds)
-      to increase/decrease how quickly you can rotate the canvas again
-      minimum value is set to 50 milliseconds (ms) which works just fine for
-      my system but you might need to increase it.
-      Don't go to low with this as if the timer gets shorter then a tick of
-      Krita's event loop the rotation won't work (you won't experiecen any
-      error as the code works just fine but the window for rotation would
-      be soo short that it ends before you can move your cursor)
-      50 ms = 0.050 s which is a very short time so you won't notice any
-      possible "lag", even increasing to 100 ms (= 0.100 s) you will be just
-      fine, feel free to adjust to anything that works for you.
-      I suggest to keep it at 50 ms if the rotation works since increasing it
-      can eventually lead to intrusive lag-like experience (for example
-      if you set the value to 1000 ms = 1 s which means you will have to wait
-      for 1 whole second until you can rotate again which I believe doesn't
-      really make sense for anyone but I'm leaving this note here just in case)
+      to increase/decrease how smooth the ccustom canvas rotaion is.
+      The lower the smoother experience but more cpu intensive (overall it's not a very expensive process
+      so you are fine with going half way down if you feel like it)
+      Don't go to much towards 0 if possible since at very low rates you can get to the moment when
+      krita event loop is as fast as this timer and the rotation will thus fail
 
 ## 5/ Known Issues
-- There's a slight delay at the beginning
-    No solution so far
 - A red crossed circle might appear while rotating the canvas (or may hang around after)
     Solution:   This it not a problem but a feature. This tells you the layer is locked
                 so you know you can't draw on it. Krita doesn't do update when the lock
@@ -137,13 +125,6 @@ Default shortcut: Ctrl + Alt + D
     performance is probably just slow or got stuck by something. If restart of your machine
     doesn't help you can simply increase TIMER_INTERVAL (check the section 5/ above) a bit
     to reduce performance drain.
-- I can't guarantee this plugin will work with pen buttons and/or tablet buttons.
-    Since this plugin uses PyQt/Krita buil-it key repeat there's a possibility that
-    some pen buttons and/or tablet/dispaly buttons don't offer this feature and
-    only utilize keyPress/KeyRelease event (or only keyPress) once with button press.
-    This could be worked around with keyPress and keyRelease PyQt but so far I
-    haven't found a way to make this work in Krita (not with default shortcuts).
-    Keyboards should work just fine for the shortcut
 
 ## 6/ Possible future updates
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -134,7 +134,7 @@ class CustomCanvasRotationExtension(Extension):
 
     def eventFilter(self, obj, e):
       # if e.type() == QEvent.KeyRelease:
-      Dialog("KeyPress event key", str(e.type()))
+      # Dialog("KeyPress event key", str(e.type()))
       return False
 
   # Reset everything back to default state to be ready for next rotation event

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -98,10 +98,11 @@ cursor_init_position = None                           # Cursor position when cus
 base_vector = [1, 0]                                  # Unit vector as reference to measure angle from
 timer = QTimer()                                      # Handles reset to init state
 timer.setInterval(TIMER_INTERVAL)
+timer.setSingleShot(True)
 release_timer = QTimer()
 release_timer.setInterval(TIMER_INTERVAL * 2)
 release_timer.setSingleShot(True)
-key_release_lock = False
+timer_lock = False
 
 # Class for testing (replaces a print statement as I don't know how to print on win)
 class Dialog(QDialog):
@@ -225,11 +226,13 @@ class CustomCanvasRotationExtension(Extension):
       global cursor_init_position
       global base_vector
       global timer
-      
+      global timer_lock
+
       canvas = Krita.instance().activeWindow().activeView().canvas()
       
       # Init custom rotation (vars, timer, active layer reference)
       key_release_lock = False
+      timer_lock = False
       cursor_init_position = QCursor.pos()
       angle = canvas.rotation()
       current_active_layer = Krita.instance().activeDocument().activeNode()

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -121,6 +121,18 @@ class Dialog(QDialog):
       self.resize(200, 50)
       self.exec_()
 
+def dot_product(v1, v2):
+  return v1[0] * v2[0] + v1[1] * v2[1]
+
+def determinant(v1, v2):
+  return v1[0] * v2[1] - v1[1] * v2[0]
+
+def vector_angle(v1, v2):
+  return  math.degrees( math.atan2(determinant(v1, v2), dot_product(v1, v2)) )
+
+def two_point_distance(v1, v2):
+  return math.sqrt( math.pow(( v2.x() - v1.x() ), 2) + math.pow(( v2.y() - v1.y() ), 2)  )
+
 # Reset everything back to default state to be ready for next rotation event
 def rotate_timer_timeout(self):
   global current_active_layer
@@ -135,7 +147,7 @@ def rotate_timer_timeout(self):
   if not buffer_lock:
     # Distance from initial point (cursor position trigger event was onvoked from)
     # to cursor's current position
-    distance = self.two_point_distance(cursor_init_position, QCursor.pos())
+    distance = two_point_distance(cursor_init_position, QCursor.pos())
     
     # If cursor outside buffer zone start immediately calculate initial offset angle
     # to ensure smooth transition when changing angles in followint passes
@@ -145,13 +157,13 @@ def rotate_timer_timeout(self):
       v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
       v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
       
-      init_offset_angle = self.vector_angle(v1, v2)
+      init_offset_angle = vector_angle(v1, v2)
   elif buffer_lock:
     # This handles the canvas rotation itself
     v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
     v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
     
-    canvas.setRotation(angle - init_offset_angle + self.vector_angle(v1, v2))
+    canvas.setRotation(angle - init_offset_angle + vector_angle(v1, v2))
 
 class CustomCanvasRotationExtension(Extension):
   def __init__(self,parent):
@@ -188,18 +200,6 @@ class CustomCanvasRotationExtension(Extension):
         current_active_layer = None
         
       return False
-
-  def dot_product(v1, v2):
-    return v1[0] * v2[0] + v1[1] * v2[1]
-
-  def determinant(v1, v2):
-    return v1[0] * v2[1] - v1[1] * v2[0]
-
-  def vector_angle(v1, v2):
-    return  math.degrees( math.atan2(determinant(v1, v2), dot_product(v1, v2)) )
-
-  def two_point_distance(v1, v2):
-    return math.sqrt( math.pow(( v2.x() - v1.x() ), 2) + math.pow(( v2.y() - v1.y() ), 2)  )
 
   def setup(self):
     pass

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -239,6 +239,6 @@ class CustomCanvasRotationExtension(Extension):
       # timeout event) and starts again. Timer will keep running as long as the
       # shortcut is being pressed
       timer.start()
-          
+      Dialog("Release", "event")
 
 Krita.instance().addExtension(CustomCanvasRotationExtension(Krita.instance()))

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -209,11 +209,12 @@ class CustomCanvasRotationExtension(Extension):
   def createActions(self, window):
     self.c_canvas_rotation = window.createAction("c_canvas_rotation", "Custom Canvas Rotation")
     self.c_canvas_rotation.setAutoRepeat(False)
+    self.c_canvas_rotation.setCheckable(True)
 
     self.MAFilter = self.mdiAreaFilter()
 
-    @self.c_canvas_rotation.triggered.connect
-    def on_trigger():
+    @self.c_canvas_rotation.toggled.connect
+    def on_toggle():
       global current_active_layer
       global current_active_layer_locked_original
       global angle

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -138,8 +138,6 @@ def release_timer_timeout():
   global base_vector
   global timer
 
-  Dialog("timer state", timer.isActive())
-  Dialog("timer time", timer.remainingTime())
   timer.stop()
 
   key_release_lock = True
@@ -198,13 +196,10 @@ class CustomCanvasRotationExtension(Extension):
       global release_timer
       
       if e.type() == QEvent.KeyRelease:
-        Dialog("timer state", release_timer.isActive())
-        Dialog("timer time", release_timer.remainingTime())
         if key_release_lock:
           return False
 
-        if release_timer.remainingTime() > 0:
-          release_timer.start()
+        release_timer.start()
         
       return False
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -126,6 +126,7 @@ class CustomCanvasRotationExtension(Extension):
     self.timer = QTimer()                                     # Handles reset to init state
     self.timer.setInterval(self.timer_interval)
     self.timer.timeout.connect(self.rotate_timer_timeout)
+    Dialog("Shortcut?", str( self.shortcut() ))
     super(CustomCanvasRotationExtension, self).__init__(parent)
 
   class mdiAreaFilter(QMdiArea):

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -127,67 +127,67 @@ def vector_angle(v1, v2):
 def two_point_distance(v1, v2):
   return math.sqrt( math.pow(( v2.x() - v1.x() ), 2) + math.pow(( v2.y() - v1.y() ), 2)  )
 
-def release_timer_timeout():
-  global current_active_layer
-  global current_active_layer_locked_original
-  global angle
-  global buffer_lock
-  global key_release_lock
-  global init_offset_angle
-  global cursor_init_position
-  global base_vector
-  global timer
+# def release_timer_timeout():
+#   global current_active_layer
+#   global current_active_layer_locked_original
+#   global angle
+#   global buffer_lock
+#   global key_release_lock
+#   global init_offset_angle
+#   global cursor_init_position
+#   global base_vector
+#   global timer
 
-  timer.stop()
-  Dialog("timer state", timer.active())
-  Dialog("timer time", timer.remainingTime())
-  key_release_lock = True
-  cursor_init_position = None
-  buffer_lock = False
-  init_offset_angle = 0
-  angle = 0
-  current_active_layer.setLocked(current_active_layer_locked_original)
-  current_active_layer = None
+#   Dialog("timer state", timer.active())
+#   Dialog("timer time", timer.remainingTime())
+#   timer.stop()
 
-# Reset everything back to default state to be ready for next rotation event
-def rotate_timer_timeout():
-  global current_active_layer
-  global current_active_layer_locked_original
-  global angle
-  global buffer_lock
-  global init_offset_angle
-  global cursor_init_position
-  global base_vector
-  global timer
+#   key_release_lock = True
+#   cursor_init_position = None
+#   buffer_lock = False
+#   init_offset_angle = 0
+#   angle = 0
+#   current_active_layer.setLocked(current_active_layer_locked_original)
+#   current_active_layer = None
 
-  if not buffer_lock:
-    # Distance from initial point (cursor position trigger event was onvoked from)
-    # to cursor's current position
-    distance = two_point_distance(cursor_init_position, QCursor.pos())
+# # Reset everything back to default state to be ready for next rotation event
+# def rotate_timer_timeout():
+#   global current_active_layer
+#   global current_active_layer_locked_original
+#   global angle
+#   global buffer_lock
+#   global init_offset_angle
+#   global cursor_init_position
+#   global base_vector
+#   global timer
+
+#   if not buffer_lock:
+#     # Distance from initial point (cursor position trigger event was onvoked from)
+#     # to cursor's current position
+#     distance = two_point_distance(cursor_init_position, QCursor.pos())
     
-    # If cursor outside buffer zone start immediately calculate initial offset angle
-    # to ensure smooth transition when changing angles in followint passes
-    if distance > DISTANCE_BUFFER:
-      buffer_lock = True
+#     # If cursor outside buffer zone start immediately calculate initial offset angle
+#     # to ensure smooth transition when changing angles in followint passes
+#     if distance > DISTANCE_BUFFER:
+#       buffer_lock = True
 
-      v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
-      v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
+#       v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
+#       v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
       
-      init_offset_angle = vector_angle(v1, v2)
-  elif buffer_lock:
-    # This handles the canvas rotation itself
-    v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
-    v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
+#       init_offset_angle = vector_angle(v1, v2)
+#   elif buffer_lock:
+#     # This handles the canvas rotation itself
+#     v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
+#     v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
     
-    canvas = Krita.instance().activeWindow().activeView().canvas()
-    canvas.setRotation(angle - init_offset_angle + vector_angle(v1, v2))
+#     canvas = Krita.instance().activeWindow().activeView().canvas()
+#     canvas.setRotation(angle - init_offset_angle + vector_angle(v1, v2))
+
+# timer.timeout.connect(rotate_timer_timeout)
+# release_timer.timeout.connect(release_timer_timeout)
 
 class CustomCanvasRotationExtension(Extension):
   def __init__(self,parent):
-    global timer
-    global release_timer
-    timer.timeout.connect(rotate_timer_timeout)
-    release_timer.timeout.connect(release_timer_timeout)
     super(CustomCanvasRotationExtension, self).__init__(parent)
 
   class mdiAreaFilter(QMdiArea):
@@ -198,6 +198,8 @@ class CustomCanvasRotationExtension(Extension):
       global release_timer
       
       if e.type() == QEvent.KeyRelease:
+        Dialog("timer state", release_timer.active())
+        Dialog("timer time", release_timer.remainingTime())
         if key_release_lock:
           return False
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -133,8 +133,8 @@ class CustomCanvasRotationExtension(Extension):
         super().__init__(parent)
 
     def eventFilter(self, obj, e):
-      if e.type() == QEvent.KeyRelease:
-        Dialog("KeyPress event key", str(e.key()))
+      # if e.type() == QEvent.KeyRelease:
+      Dialog("KeyPress event key", str(e.type()))
       return False
 
   # Reset everything back to default state to be ready for next rotation event

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -127,64 +127,64 @@ def vector_angle(v1, v2):
 def two_point_distance(v1, v2):
   return math.sqrt( math.pow(( v2.x() - v1.x() ), 2) + math.pow(( v2.y() - v1.y() ), 2)  )
 
-# def release_timer_timeout():
-#   global current_active_layer
-#   global current_active_layer_locked_original
-#   global angle
-#   global buffer_lock
-#   global key_release_lock
-#   global init_offset_angle
-#   global cursor_init_position
-#   global base_vector
-#   global timer
+def release_timer_timeout():
+  global current_active_layer
+  global current_active_layer_locked_original
+  global angle
+  global buffer_lock
+  global key_release_lock
+  global init_offset_angle
+  global cursor_init_position
+  global base_vector
+  global timer
 
-#   Dialog("timer state", timer.active())
-#   Dialog("timer time", timer.remainingTime())
-#   timer.stop()
+  Dialog("timer state", timer.active())
+  Dialog("timer time", timer.remainingTime())
+  timer.stop()
 
-#   key_release_lock = True
-#   cursor_init_position = None
-#   buffer_lock = False
-#   init_offset_angle = 0
-#   angle = 0
-#   current_active_layer.setLocked(current_active_layer_locked_original)
-#   current_active_layer = None
+  key_release_lock = True
+  cursor_init_position = None
+  buffer_lock = False
+  init_offset_angle = 0
+  angle = 0
+  current_active_layer.setLocked(current_active_layer_locked_original)
+  current_active_layer = None
 
-# # Reset everything back to default state to be ready for next rotation event
-# def rotate_timer_timeout():
-#   global current_active_layer
-#   global current_active_layer_locked_original
-#   global angle
-#   global buffer_lock
-#   global init_offset_angle
-#   global cursor_init_position
-#   global base_vector
-#   global timer
+# Reset everything back to default state to be ready for next rotation event
+def rotate_timer_timeout():
+  global current_active_layer
+  global current_active_layer_locked_original
+  global angle
+  global buffer_lock
+  global init_offset_angle
+  global cursor_init_position
+  global base_vector
+  global timer
 
-#   if not buffer_lock:
-#     # Distance from initial point (cursor position trigger event was onvoked from)
-#     # to cursor's current position
-#     distance = two_point_distance(cursor_init_position, QCursor.pos())
+  if not buffer_lock:
+    # Distance from initial point (cursor position trigger event was onvoked from)
+    # to cursor's current position
+    distance = two_point_distance(cursor_init_position, QCursor.pos())
     
-#     # If cursor outside buffer zone start immediately calculate initial offset angle
-#     # to ensure smooth transition when changing angles in followint passes
-#     if distance > DISTANCE_BUFFER:
-#       buffer_lock = True
+    # If cursor outside buffer zone start immediately calculate initial offset angle
+    # to ensure smooth transition when changing angles in followint passes
+    if distance > DISTANCE_BUFFER:
+      buffer_lock = True
 
-#       v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
-#       v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
+      v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
+      v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
       
-#       init_offset_angle = vector_angle(v1, v2)
-#   elif buffer_lock:
-#     # This handles the canvas rotation itself
-#     v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
-#     v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
+      init_offset_angle = vector_angle(v1, v2)
+  elif buffer_lock:
+    # This handles the canvas rotation itself
+    v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
+    v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
     
-#     canvas = Krita.instance().activeWindow().activeView().canvas()
-#     canvas.setRotation(angle - init_offset_angle + vector_angle(v1, v2))
+    canvas = Krita.instance().activeWindow().activeView().canvas()
+    canvas.setRotation(angle - init_offset_angle + vector_angle(v1, v2))
 
-# timer.timeout.connect(rotate_timer_timeout)
-# release_timer.timeout.connect(release_timer_timeout)
+timer.timeout.connect(rotate_timer_timeout)
+release_timer.timeout.connect(release_timer_timeout)
 
 class CustomCanvasRotationExtension(Extension):
   def __init__(self,parent):

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -240,6 +240,6 @@ class CustomCanvasRotationExtension(Extension):
       # timeout event) and starts again. Timer will keep running as long as the
       # shortcut is being pressed
       timer.start()
-      Dialog("Release", "event")
+
 
 Krita.instance().addExtension(CustomCanvasRotationExtension(Krita.instance()))

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -126,9 +126,9 @@ class CustomCanvasRotationExtension(Extension):
     self.timer = QTimer()                                     # Handles reset to init state
     self.timer.setInterval(self.timer_interval)
     self.timer.timeout.connect(self.rotate_timer_timeout)
-    Dialog("Shortcut?", str( self.shortcut() ))
     super(CustomCanvasRotationExtension, self).__init__(parent)
-
+    Dialog("Shortcut?", str( self.shortcut() ))
+    
   class mdiAreaFilter(QMdiArea):
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -152,7 +152,7 @@ class CustomCanvasRotationExtension(Extension):
 
   def createActions(self, window):
     self.c_canvas_rotation = window.createAction("c_canvas_rotation", "Custom Canvas Rotation")
-    self.c_canvas_rotation.setAutoRepeat(True)
+    self.c_canvas_rotation.setAutoRepeat(False)
     
     self.qwin = window.qwindow()
     self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -149,7 +149,7 @@ class CustomCanvasRotationExtension(Extension):
     def on_trigger():
       canvas = Krita.instance().activeWindow().activeView().canvas()
 
-      # Init custom rotation (vars, timer, active layer reference)
+      # Init custom rotation (vars, timer, active layer reference
       if not self.key_press_lock:
         self.key_press_lock = True
         self.cursor_init_position = QCursor.pos()

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -98,6 +98,7 @@ cursor_init_position = None                           # Cursor position when cus
 base_vector = [1, 0]                                  # Unit vector as reference to measure angle from
 timer = QTimer()                                      # Handles reset to init state
 timer.setInterval(TIMER_INTERVAL)
+timer.setSingleShot(True)
 release_timer = QTimer()
 release_timer.setInterval(TIMER_INTERVAL * 2)
 release_timer.setSingleShot(True)
@@ -182,8 +183,7 @@ def rotate_timer_timeout():
     canvas = Krita.instance().activeWindow().activeView().canvas()
     canvas.setRotation(angle - init_offset_angle + vector_angle(v1, v2))
 
-timer.timeout.connect(rotate_timer_timeout)
-release_timer.timeout.connect(release_timer_timeout)
+  timer.start()
 
 class CustomCanvasRotationExtension(Extension):
   def __init__(self,parent):
@@ -243,5 +243,7 @@ class CustomCanvasRotationExtension(Extension):
       # shortcut is being pressed
       timer.start()
 
+timer.timeout.connect(rotate_timer_timeout)
+release_timer.timeout.connect(release_timer_timeout)
 
 Krita.instance().addExtension(CustomCanvasRotationExtension(Krita.instance()))

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -71,7 +71,6 @@ from krita import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtCore import QTimer
 import math
-import inspect
 
 DISTANCE_BUFFER = 3           # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
                               # Units: Pixels (screen not canvas pixels)
@@ -111,9 +110,6 @@ class Dialog(QDialog):
         self.resize(200, 50)
         self.exec_()
 
-def getInfo(target):
-    [Dialog("Item", item) for item in inspect.getmembers(target) if not item[0].startswith('_')]
-
 class CustomCanvasRotationExtension(Extension):
   def __init__(self,parent):
     self.current_active_layer = None
@@ -132,15 +128,18 @@ class CustomCanvasRotationExtension(Extension):
     self.timer.timeout.connect(self.rotate_timer_timeout)
     super(CustomCanvasRotationExtension, self).__init__(parent)
 
-  class mdiAreaFilter(QMdiArea):
-    def __init__(self, parent=None):
-        super().__init__(parent)
+  # class mdiAreaFilter(QMdiArea):
+  #   def __init__(self, parent=None):
+  #       super().__init__(parent)
 
-    def eventFilter(self, obj, e):
-      # if e.type() == QEvent.KeyRelease:
-      # Dialog("KeyPress event key", str(e.type()))
-      return False
-
+  #   def eventFilter(self, obj, e):
+  #     if e.type() == QEvent.KeyRelease:
+        
+  #     return False
+  def eventFilter(self, obj, e):
+    if e.type() == QEvent.KeyRelease:
+      Dialog("Release", "testFilter")
+      
   # Reset everything back to default state to be ready for next rotation event
   def rotate_timer_timeout(self):
     self.key_press_lock = False
@@ -157,8 +156,7 @@ class CustomCanvasRotationExtension(Extension):
   def createActions(self, window):
     self.c_canvas_rotation = window.createAction("c_canvas_rotation", "Custom Canvas Rotation")
     self.c_canvas_rotation.setAutoRepeat(False)
-    # Dialog("Shortcut", str( self.c_canvas_rotation.shortcut() ))
-    # getInfo(self.c_canvas_rotation.shortcut())
+
     # self.qwin = window.qwindow()
     # self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -154,11 +154,11 @@ class CustomCanvasRotationExtension(Extension):
     self.c_canvas_rotation = window.createAction("c_canvas_rotation", "Custom Canvas Rotation")
     self.c_canvas_rotation.setAutoRepeat(False)
     
-    self.qwin = window.qwindow()
-    self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
+    # self.qwin = window.qwindow()
+    # self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 
-    self.mdiAreaFilter = self.mdiAreaFilter()
-    self.mdiArea.installEventFilter(self.mdiAreaFilter)
+    # self.mdiAreaFilter = self.mdiAreaFilter()
+    # self.mdiArea.installEventFilter(self.mdiAreaFilter)
 
     # @self.c_canvas_rotation.triggered.connect
     # def on_trigger():

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -71,6 +71,7 @@ from krita import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtCore import QTimer
 import math
+import inspect
 
 DISTANCE_BUFFER = 3           # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
                               # Units: Pixels (screen not canvas pixels)
@@ -109,6 +110,9 @@ class Dialog(QDialog):
         self.layout().addWidget(self.label2)
         self.resize(200, 50)
         self.exec_()
+
+def getInfo(target):
+    [Dialog("Item", item) for item in inspect.getmembers(target) if not item[0].startswith('_')]
 
 class CustomCanvasRotationExtension(Extension):
   def __init__(self,parent):
@@ -153,7 +157,8 @@ class CustomCanvasRotationExtension(Extension):
   def createActions(self, window):
     self.c_canvas_rotation = window.createAction("c_canvas_rotation", "Custom Canvas Rotation")
     self.c_canvas_rotation.setAutoRepeat(False)
-    Dialog("Shortcut", str( self.c_canvas_rotation.shortcut() ))
+    # Dialog("Shortcut", str( self.c_canvas_rotation.shortcut() ))
+    getInfo(self.c_canvas_rotation.shortcut())
     # self.qwin = window.qwindow()
     # self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -127,8 +127,7 @@ class CustomCanvasRotationExtension(Extension):
     self.timer.setInterval(self.timer_interval)
     self.timer.timeout.connect(self.rotate_timer_timeout)
     super(CustomCanvasRotationExtension, self).__init__(parent)
-    Dialog("Shortcut?", str( self.shortcut() ))
-    
+
   class mdiAreaFilter(QMdiArea):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -154,7 +153,7 @@ class CustomCanvasRotationExtension(Extension):
   def createActions(self, window):
     self.c_canvas_rotation = window.createAction("c_canvas_rotation", "Custom Canvas Rotation")
     self.c_canvas_rotation.setAutoRepeat(False)
-    
+    Dialog("Shortcut", str( self.c_canvas_rotation.shortcut() ))
     # self.qwin = window.qwindow()
     # self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -128,7 +128,7 @@ class CustomCanvasRotationExtension(Extension):
     self.timer.timeout.connect(self.rotate_timer_timeout)
     super(CustomCanvasRotationExtension, self).__init__(parent)
 
-  class mdiAreaFilter(QWindow):
+  class mdiAreaFilter(QMdiArea):
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -158,7 +158,7 @@ class CustomCanvasRotationExtension(Extension):
     self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 
     self.mdiAreaFilter = self.mdiAreaFilter()
-    self.qwin.installEventFilter(self.mdiAreaFilter)
+    self.mdiAreaFilter.installEventFilter(self.mdiAreaFilter)
 
     # @self.c_canvas_rotation.triggered.connect
     # def on_trigger():

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -98,7 +98,6 @@ cursor_init_position = None                           # Cursor position when cus
 base_vector = [1, 0]                                  # Unit vector as reference to measure angle from
 timer = QTimer()                                      # Handles reset to init state
 timer.setInterval(TIMER_INTERVAL)
-timer.setSingleShot(True)
 release_timer = QTimer()
 release_timer.setInterval(TIMER_INTERVAL * 2)
 release_timer.setSingleShot(True)
@@ -140,6 +139,8 @@ def release_timer_timeout():
   global timer
 
   timer.stop()
+  Dialog("timer state", timer.active())
+  Dialog("timer time", timer.remainingTime())
   key_release_lock = True
   cursor_init_position = None
   buffer_lock = False
@@ -200,7 +201,7 @@ class CustomCanvasRotationExtension(Extension):
         if key_release_lock:
           return False
 
-        if release_timer.isActive():
+        if release_timer.remainingTime() > 0:
           release_timer.start()
         
       return False

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -138,7 +138,7 @@ def release_timer_timeout():
   global base_vector
   global timer
 
-  Dialog("timer state", timer.active())
+  Dialog("timer state", timer.isActive())
   Dialog("timer time", timer.remainingTime())
   timer.stop()
 
@@ -198,7 +198,7 @@ class CustomCanvasRotationExtension(Extension):
       global release_timer
       
       if e.type() == QEvent.KeyRelease:
-        Dialog("timer state", release_timer.active())
+        Dialog("timer state", release_timer.isActive())
         Dialog("timer time", release_timer.remainingTime())
         if key_release_lock:
           return False

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -191,7 +191,6 @@ class CustomCanvasRotationExtension(Extension):
         return False
 
       if e.type() == QEvent.KeyRelease:
-        Dialog("Release", "event")
         timer.stop()
         key_release_lock = True
         cursor_init_position = None

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -158,7 +158,7 @@ class CustomCanvasRotationExtension(Extension):
     self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 
     self.mdiAreaFilter = self.mdiAreaFilter()
-    self.mdiAreaFilter.installEventFilter(self.mdiAreaFilter)
+    self.mdiArea.installEventFilter(self.mdiAreaFilter)
 
     # @self.c_canvas_rotation.triggered.connect
     # def on_trigger():

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -191,6 +191,7 @@ class CustomCanvasRotationExtension(Extension):
         return False
 
       if e.type() == QEvent.KeyRelease:
+        Dialog("Release", "event")
         timer.stop()
         key_release_lock = True
         cursor_init_position = None

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -149,7 +149,7 @@ class CustomCanvasRotationExtension(Extension):
     def on_trigger():
       canvas = Krita.instance().activeWindow().activeView().canvas()
 
-      # Init custom rotation (vars, timer, active layer reference
+      # Init custom rotation (vars, timer, active layer reference)
       if not self.key_press_lock:
         self.key_press_lock = True
         self.cursor_init_position = QCursor.pos()

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -163,6 +163,7 @@ def rotate_timer_timeout():
     v1 = [base_vector[0] - cursor_init_position.x(), base_vector[1] - cursor_init_position.y()]
     v2 = [QCursor.pos().x() - cursor_init_position.x(), QCursor.pos().y() - cursor_init_position.y()]
     
+    canvas = Krita.instance().activeWindow().activeView().canvas()
     canvas.setRotation(angle - init_offset_angle + vector_angle(v1, v2))
 
 class CustomCanvasRotationExtension(Extension):

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -79,7 +79,7 @@ DISTANCE_BUFFER = 10          # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
                               # In future it might also serve as a reset for canvas reset to facilitate another function related to
                               # canvas rotation.
 
-TIMER_INTERVAL = 30           # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
+TIMER_INTERVAL = 50           # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
                               # Units: Miliseconds
                               # For me 50ms works as minimum value just fine.
                               # (you can go higher, if you need a lot more than this
@@ -145,7 +145,8 @@ def release_timer_timeout():
   buffer_lock = False
   init_offset_angle = 0
   angle = 0
-  current_active_layer.setLocked(current_active_layer_locked_original)
+  if current_active_layer != None:
+    current_active_layer.setLocked(current_active_layer_locked_original)
   current_active_layer = None
 
 # Reset everything back to default state to be ready for next rotation event

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -128,7 +128,7 @@ class CustomCanvasRotationExtension(Extension):
     self.timer.timeout.connect(self.rotate_timer_timeout)
     super(CustomCanvasRotationExtension, self).__init__(parent)
 
-  class mdiAreaFilter(QMdiArea):
+  class mdiAreaFilter(Qwindow):
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -158,7 +158,7 @@ class CustomCanvasRotationExtension(Extension):
     self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 
     self.mdiAreaFilter = self.mdiAreaFilter()
-    self.mdiArea.installEventFilter(self.mdiAreaFilter)
+    self.qwin.installEventFilter(self.mdiAreaFilter)
 
     # @self.c_canvas_rotation.triggered.connect
     # def on_trigger():

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -79,7 +79,7 @@ DISTANCE_BUFFER = 10          # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
                               # In future it might also serve as a reset for canvas reset to facilitate another function related to
                               # canvas rotation.
 
-TIMER_INTERVAL = 50           # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
+TIMER_INTERVAL = 30           # THIS VALUE CAN BE CHANGED TO FIT YOUR NEEDS!
                               # Units: Miliseconds
                               # For me 50ms works as minimum value just fine.
                               # (you can go higher, if you need a lot more than this

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -133,7 +133,7 @@ class CustomCanvasRotationExtension(Extension):
         super().__init__(parent)
 
     def eventFilter(self, obj, e):
-      if e.type() == QEvent.KeyPress:
+      if e.type() == QEvent.KeyRelease:
         Dialog("KeyPress event key", str(e.key()))
       return False
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -158,7 +158,7 @@ class CustomCanvasRotationExtension(Extension):
     self.c_canvas_rotation = window.createAction("c_canvas_rotation", "Custom Canvas Rotation")
     self.c_canvas_rotation.setAutoRepeat(False)
     # Dialog("Shortcut", str( self.c_canvas_rotation.shortcut() ))
-    getInfo(self.c_canvas_rotation.shortcut())
+    # getInfo(self.c_canvas_rotation.shortcut())
     # self.qwin = window.qwindow()
     # self.mdiArea = self.qwin.centralWidget().findChild(QMdiArea)
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -128,7 +128,7 @@ class CustomCanvasRotationExtension(Extension):
     self.timer.timeout.connect(self.rotate_timer_timeout)
     super(CustomCanvasRotationExtension, self).__init__(parent)
 
-  class mdiAreaFilter(Qwindow):
+  class mdiAreaFilter(QWindow):
     def __init__(self, parent=None):
         super().__init__(parent)
 

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -134,7 +134,7 @@ def two_point_distance(v1, v2):
   return math.sqrt( math.pow(( v2.x() - v1.x() ), 2) + math.pow(( v2.y() - v1.y() ), 2)  )
 
 # Reset everything back to default state to be ready for next rotation event
-def rotate_timer_timeout(self):
+def rotate_timer_timeout():
   global current_active_layer
   global current_active_layer_locked_original
   global angle

--- a/c_canvas_rotation/__init__.py
+++ b/c_canvas_rotation/__init__.py
@@ -90,7 +90,7 @@ current_active_layer = None
 current_active_layer_locked_original = False
 angle = 0                                             # Current canvas rotation
 buffer_lock = False                                   # After cursor moves out of buffer area removes the buffer condition
-key_release_lock = False                              # Locks initial key press (sets initial values for trigger event only at the
+key_release_lock = True                              # Locks initial key press (sets initial values for trigger event only at the
                                                       # beginning of the event, these values are reset in the timeout method of the timer below)
 init_offset_angle = 0                                 # An angle to keep smooth transition
                                                       # (vectors: v1 = base_vector - init; v2 = cursor (immediately after leaving buffer area) - init)


### PR DESCRIPTION
Replacing Trigger + QTimer by 2x QTimer + Toggle

Results in no freeze at the beginning.
Immediate response.
Form only keyboard now works with keyboard, pen buttons, tablet/display buttons, ...

TIMER_INTERVAL now relates to how smooth the animation is (it's literally how quick the event (QTimer) loop's step is, it's very straightforwad now.

It's a bit of a dirty solution but I can't figure out anything better.

Known issues:
1. If the cursors stops for a while on any icon the icon gets focus and this stops the rotation (it takes a while for the focus to happen so it's should be ok for general use + cursor is not over GUI when you rotate the canvas most of the time anyway